### PR TITLE
Allow user to override hostname

### DIFF
--- a/src/MailgunTransport.ts
+++ b/src/MailgunTransport.ts
@@ -11,6 +11,7 @@ const ADDRESS_KEYS: Array<string> = ['from', 'to', 'cc', 'bcc', 'replyTo'];
 const CONTENT_KEYS: Array<string> = ['subject', 'text', 'html'];
 
 export interface Options {
+  hostname?: string;
   auth: {
     domain: string;
     apiKey: string;
@@ -27,7 +28,7 @@ export class MailgunTransport implements Transport {
   constructor(options: Options) {
     this.requestConfig = {
       protocol: 'https:',
-      hostname: `api.mailgun.net`,
+      hostname: options.hostname || 'api.mailgun.net',
       path: `/v3/${options.auth.domain}/messages`,
       auth: `api:${options.auth.apiKey}`
     };


### PR DESCRIPTION
Hey.

It appears that mailgun has a different API hostname for EU domains (`api.eu.mailgun.net`). This PR allows one to change hostname in case this happens. If they decided to add more, this PR should be able to handle it.