### PR TITLE
Add 'error' handler on HTTP request

### DIFF
--- a/src/MailgunTransport.spec.ts
+++ b/src/MailgunTransport.spec.ts
@@ -128,3 +128,24 @@ test('test the Mailgun error', (done: Function) => {
     done();
   });
 });
+
+test('test request error', (done: Function) => {
+  expect.assertions(1);
+
+  createTransport(new MailgunTransport(<Options>{
+    hostname: 'localhost',
+    auth: {
+      domain: 'sandbox.mailgun.org',
+      apiKey: 'API_KEY-HERE'
+    }
+  })).sendMail({
+    from: 'sergey@emailjs.com',
+    to: 'Sergey <sergey@emailjs.com>',
+    subject: 'Mailgun Transport Error'
+  }).then((info) => {
+    throw info;
+  }, (error) => {
+    expect(error).toBeDefined();
+    done();
+  });
+});

--- a/src/MailgunTransport.ts
+++ b/src/MailgunTransport.ts
@@ -104,6 +104,9 @@ export class MailgunTransport implements Transport {
           reject(error);
         });
       });
+      req.on('error', (error) => {
+        reject(error);
+      })
     });
   }
 


### PR DESCRIPTION
The latest version of library (v1.2.1) is subject to uncaught exceptions when an outgoing HTTP request results in an `ECONNRESET` error.

This PR adds a handler for the `'error'` event emitted by the HTTP `req` object. The handler makes sure the error is passed back to the caller by rejecting the returned `Promise`.

A test was added also to cover this case (set `hostname` to `'localhost'` and handle the `ECONNREFUSED` error).