### PR TITLE
Add proxy to options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 node_modules/
 coverage/
-dist/
 .idea/
 *.swp
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -81,6 +81,41 @@ __send attachment and add to content__
   });
 ```
 
+__send email through a proxy using forwarding__
+``` js
+  // same imports as above
+
+  let transporter = nodemailer.createTransport(new MailgunTransport({
+    proxy: {
+      protocol: "http",
+      host: "www.myproxy.com",
+      port: 80
+    }
+    // auth key-value if applicable
+  }));
+
+  // send email as done above
+```
+
+__send an email through a proxy using any http.Agent or https.Agent, .i.e. using `node-tunnel`__
+``` js
+  // same imports as above
+  const tunnel = require('tunnel');
+
+  let transporter = nodemailer.createTransport(new MailgunTransport({
+    // agent can be any instance of http.Agent or https.Agent
+    agent: tunnel.httpsOverHttp({ // or httpOverHttps, httpOverHttp, or httpsOverHttps
+      proxy: {
+        host: "www.myproxy.com",
+        port: 80
+      }
+    })
+    // auth key-value if applicable
+  }));
+
+  // send email as done above
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/dist/MailgunTransport.d.ts
+++ b/dist/MailgunTransport.d.ts
@@ -16,6 +16,7 @@ export interface Options {
 export declare class MailgunTransport implements Transport {
     private readonly requestConfig;
     private cids;
+    private isHttp;
     name: string;
     version: string;
     constructor(options: Options);

--- a/dist/MailgunTransport.d.ts
+++ b/dist/MailgunTransport.d.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+import { Agent as httpAgent } from 'http';
+import { Agent as httpsAgent } from 'https';
 import type { SentMessageInfo, Transport } from 'nodemailer';
 import type MailMessage from 'nodemailer/lib/mailer/mail-message';
 interface Proxy {
@@ -8,6 +11,7 @@ interface Proxy {
 export interface Options {
     hostname?: string;
     proxy?: Proxy;
+    agent?: httpAgent | httpsAgent;
     auth: {
         domain: string;
         apiKey: string;

--- a/dist/MailgunTransport.d.ts
+++ b/dist/MailgunTransport.d.ts
@@ -1,0 +1,30 @@
+import type { SentMessageInfo, Transport } from 'nodemailer';
+import type MailMessage from 'nodemailer/lib/mailer/mail-message';
+interface Proxy {
+    protocol: string;
+    host: string;
+    port: number;
+}
+export interface Options {
+    hostname?: string;
+    proxy?: Proxy;
+    auth: {
+        domain: string;
+        apiKey: string;
+    };
+}
+export declare class MailgunTransport implements Transport {
+    private readonly requestConfig;
+    private cids;
+    name: string;
+    version: string;
+    constructor(options: Options);
+    private findEmbeddedAttachments;
+    private appendAddresses;
+    private appendContent;
+    private appendImages;
+    private appendAttachments;
+    private submitForm;
+    send(mail: MailMessage, done: (err: Error | null, info?: SentMessageInfo) => void): void;
+}
+export default MailgunTransport;

--- a/dist/MailgunTransport.js
+++ b/dist/MailgunTransport.js
@@ -33,7 +33,7 @@ class MailgunTransport {
             port: options.proxy.port,
             path: `https://${targetHostname}${targetPath}`,
             headers: {
-                Host: options.proxy.host
+                Host: targetHostname
             },
             auth
         } : {

--- a/dist/MailgunTransport.js
+++ b/dist/MailgunTransport.js
@@ -4,6 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MailgunTransport = void 0;
+const http_1 = require("http");
 const https_1 = require("https");
 const form_data_1 = __importDefault(require("form-data"));
 const TRANSFORM_FIELDS = {
@@ -22,11 +23,12 @@ class MailgunTransport {
         const targetHostname = options.hostname || 'api.mailgun.net';
         const targetPath = `/v3/${options.auth.domain}/messages`;
         const auth = `api:${options.auth.apiKey}`;
+        this.isHttp = options.proxy && !options.proxy.protocol.startsWith('https');
         this.requestConfig = options.proxy ? {
-            protocol: (options.proxy.protocol && options.proxy.protocol.startsWith('https')) ? 'https:' : 'http:',
+            protocol: this.isHttp ? 'http:' : 'https:',
             hostname: options.proxy.host,
             port: options.proxy.port,
-            path: `${targetHostname}${targetPath}`,
+            path: `https://${targetHostname}${targetPath}`,
             auth
         } : {
             protocol: 'https:',
@@ -94,7 +96,7 @@ class MailgunTransport {
     }
     submitForm(form) {
         return new Promise((resolve, reject) => {
-            let req = (0, https_1.request)(Object.assign({
+            let req = (this.isHttp ? http_1.request : https_1.request)(Object.assign({
                 method: 'POST',
                 headers: form.getHeaders()
             }, this.requestConfig));

--- a/dist/MailgunTransport.js
+++ b/dist/MailgunTransport.js
@@ -1,0 +1,148 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MailgunTransport = void 0;
+const https_1 = require("https");
+const form_data_1 = __importDefault(require("form-data"));
+const TRANSFORM_FIELDS = {
+    replyTo: 'h:Reply-To'
+};
+const ADDRESS_KEYS = ['from', 'to', 'cc', 'bcc', 'replyTo'];
+const CONTENT_KEYS = ['subject', 'text', 'html'];
+const combineTarget = (target) => {
+    return target.name ? `${target.name} <${target.address}>` : target.address;
+};
+class MailgunTransport {
+    constructor(options) {
+        this.cids = {};
+        this.name = 'MailgunTransport';
+        this.version = 'N/A';
+        const targetHostname = options.hostname || 'api.mailgun.net';
+        const targetPath = `/v3/${options.auth.domain}/messages`;
+        const auth = `api:${options.auth.apiKey}`;
+        this.requestConfig = options.proxy ? {
+            protocol: (options.proxy.protocol && options.proxy.protocol.startsWith('https')) ? 'https:' : 'http:',
+            hostname: options.proxy.host,
+            port: options.proxy.port,
+            path: `${targetHostname}${targetPath}`,
+            auth
+        } : {
+            protocol: 'https:',
+            hostname: targetHostname,
+            path: targetPath,
+            auth
+        };
+    }
+    findEmbeddedAttachments(data) {
+        const content = (data.text || data.html);
+        const matchInlineImages = [...content.matchAll(/["\[]cid:(.*?)["\]]/g)];
+        this.cids = matchInlineImages.reduce((result, match) => {
+            result[match[1]] = true;
+            return result;
+        }, {});
+    }
+    appendAddresses(form, data) {
+        ADDRESS_KEYS.forEach(target => {
+            if (!data[target])
+                return;
+            let value;
+            if (Array.isArray(data[target])) {
+                value = data[target].map(combineTarget).join(',');
+            }
+            else {
+                value = combineTarget(data[target]);
+            }
+            form.append(TRANSFORM_FIELDS[target] || target, value);
+        });
+    }
+    appendContent(form, data) {
+        CONTENT_KEYS.forEach(content => {
+            if (!data[content])
+                return;
+            form.append(TRANSFORM_FIELDS[content] || content, data[content]);
+        });
+    }
+    appendImages(form, data) {
+        if (!Array.isArray(data.attachments))
+            return;
+        data.attachments.forEach((attachment) => {
+            if (attachment.contentType.startsWith('image/') && this.cids[attachment.cid]) {
+                let buffer = Buffer.from(attachment.content, attachment.encoding);
+                form.append('inline', buffer, {
+                    filename: attachment.cid,
+                    contentType: attachment.contentType,
+                    knownLength: buffer.length
+                });
+            }
+        });
+    }
+    appendAttachments(form, data) {
+        if (!Array.isArray(data.attachments))
+            return;
+        data.attachments.forEach((attachment) => {
+            if (!(attachment.contentType.startsWith('image/') && this.cids[attachment.cid])) {
+                let buffer = Buffer.from(attachment.content, attachment.encoding);
+                form.append('attachment', buffer, {
+                    filename: attachment.filename || attachment.cid,
+                    contentType: attachment.contentType,
+                    knownLength: buffer.length
+                });
+            }
+        });
+    }
+    submitForm(form) {
+        return new Promise((resolve, reject) => {
+            let req = (0, https_1.request)(Object.assign({
+                method: 'POST',
+                headers: form.getHeaders()
+            }, this.requestConfig));
+            form.pipe(req);
+            req.on('response', (res) => {
+                let chunks = [];
+                res.on('data', (chunk) => chunks.push(chunk));
+                res.on('end', () => {
+                    let answer = Buffer.concat(chunks).toString();
+                    if (res.statusCode === 200) {
+                        resolve(answer);
+                    }
+                    else {
+                        reject(answer);
+                    }
+                });
+                res.on('error', (error) => {
+                    reject(error);
+                });
+            });
+            req.on('error', (error) => {
+                reject(error);
+            });
+        });
+    }
+    send(mail, done) {
+        setImmediate(() => {
+            mail.normalize((error, data) => {
+                if (error)
+                    return done(error);
+                this.findEmbeddedAttachments(data);
+                const form = new form_data_1.default();
+                this.appendAddresses(form, data);
+                this.appendContent(form, data);
+                this.appendImages(form, data);
+                this.appendAttachments(form, data);
+                this.submitForm(form)
+                    .then(() => {
+                    done(null, {
+                        envelope: mail.message.getEnvelope(),
+                        messageId: mail.message.messageId(),
+                        message: form
+                    });
+                })
+                    .catch((e) => done(e));
+            });
+        });
+    }
+}
+exports.MailgunTransport = MailgunTransport;
+exports.default = MailgunTransport;

--- a/dist/MailgunTransport.js
+++ b/dist/MailgunTransport.js
@@ -26,9 +26,12 @@ class MailgunTransport {
         this.isHttp = options.proxy && !options.proxy.protocol.startsWith('https');
         this.requestConfig = options.proxy ? {
             protocol: this.isHttp ? 'http:' : 'https:',
-            hostname: options.proxy.host,
+            host: options.proxy.host,
             port: options.proxy.port,
             path: `https://${targetHostname}${targetPath}`,
+            headers: {
+              Host: options.proxy.host
+            },
             auth
         } : {
             protocol: 'https:',

--- a/dist/MailgunTransport.js
+++ b/dist/MailgunTransport.js
@@ -23,20 +23,24 @@ class MailgunTransport {
         const targetHostname = options.hostname || 'api.mailgun.net';
         const targetPath = `/v3/${options.auth.domain}/messages`;
         const auth = `api:${options.auth.apiKey}`;
-        this.isHttp = options.proxy && !options.proxy.protocol.startsWith('https');
-        this.requestConfig = options.proxy ? {
+        const agentOptions = options.agent ? { agent: options.agent } : {};
+        this.isHttp =
+            (options.proxy && !options.proxy.protocol.startsWith('https')) ||
+                (options.agent && options.agent instanceof http_1.Agent);
+        this.requestConfig = (!options.agent && options.proxy) ? {
             protocol: this.isHttp ? 'http:' : 'https:',
             host: options.proxy.host,
             port: options.proxy.port,
             path: `https://${targetHostname}${targetPath}`,
             headers: {
-              Host: options.proxy.host
+                Host: options.proxy.host
             },
             auth
         } : {
             protocol: 'https:',
             hostname: targetHostname,
             path: targetPath,
+            ...agentOptions,
             auth
         };
     }

--- a/src/MailgunTransport.ts
+++ b/src/MailgunTransport.ts
@@ -58,9 +58,12 @@ export class MailgunTransport implements Transport {
     this.isHttp = options.proxy && !options.proxy.protocol.startsWith('https');
     this.requestConfig = options.proxy ? {
       protocol: this.isHttp ? 'http:' : 'https:',
-      hostname: options.proxy.host,
+      host: options.proxy.host,
       port: options.proxy.port,
       path: `https://${targetHostname}${targetPath}`,
+      headers: {
+        Host: options.proxy.host
+      },
       auth
     } : {
       protocol: 'https:',

--- a/src/MailgunTransport.ts
+++ b/src/MailgunTransport.ts
@@ -68,7 +68,7 @@ export class MailgunTransport implements Transport {
       port: options.proxy.port,
       path: `https://${targetHostname}${targetPath}`,
       headers: {
-        Host: options.proxy.host
+        Host: targetHostname
       },
       auth
     } : {   // proxying via an http/https agent, i.e. node-tunnel

--- a/src/MailgunTransport.ts
+++ b/src/MailgunTransport.ts
@@ -57,7 +57,7 @@ export class MailgunTransport implements Transport {
       protocol: ( options.proxy.protocol && options.proxy.protocol.startsWith('https') ) ? 'https:' : 'http:',
       hostname: options.proxy.host,
       port: options.proxy.port,
-      path: `${targetHostname}${targetPath}`,
+      path: `https://${targetHostname}${targetPath}`,
       auth
     } : {
       protocol: 'https:',


### PR DESCRIPTION
Allow specifying a proxy configuration, either via HTTP proxy header configuration, or via an http/https agent, like the ones provided by the 'tunnel-agent' npm package.