### PR TITLE
allow proxy via headers or agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,41 @@ __send attachment and add to content__
   });
 ```
 
+__send email through a proxy using forwarding__
+``` js
+  // same imports as above
+
+  let transporter = nodemailer.createTransport(new MailgunTransport({
+    proxy: {
+      protocol: "http",
+      host: "www.myproxy.com",
+      port: 80
+    }
+    // auth key-value if applicable
+  }));
+
+  // send email as done above
+```
+
+__send an email through a proxy using any http.Agent or https.Agent, .i.e. using `node-tunnel`__
+``` js
+  // same imports as above
+  const tunnel = require('tunnel');
+
+  let transporter = nodemailer.createTransport(new MailgunTransport({
+    // agent can be any instance of http.Agent or https.Agent
+    agent: tunnel.httpsOverHttp({ // or httpOverHttps, httpOverHttp, or httpsOverHttps
+      proxy: {
+        host: "www.myproxy.com",
+        port: 80
+      }
+    })
+    // auth key-value if applicable
+  }));
+
+  // send email as done above
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/services/Requestly.ts
+++ b/src/services/Requestly.ts
@@ -1,11 +1,17 @@
-import { request, RequestOptions } from 'https';
+import { request as requestHttp, RequestOptions as HttpRequestOptions } from 'http';
+import { request as requestHttps, RequestOptions as HttpsRequestOptions } from 'https';
 import FormData from 'form-data';
 
 import type { IncomingMessage } from 'http';
 
-function sendRequest(options: RequestOptions, formData: FormData): Promise<string> {
+
+function sendRequest(
+  options: HttpRequestOptions | HttpsRequestOptions,
+  formData: FormData,
+  isHttpProxy=false,
+  ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const req = request(options);
+    const req = (isHttpProxy ? requestHttp : requestHttps)(options);
 
     formData.pipe(req);
 
@@ -37,9 +43,13 @@ function sendRequest(options: RequestOptions, formData: FormData): Promise<strin
   });
 }
 
-export function postForm(options: RequestOptions, formData: FormData): Promise<string> {
+export function postForm(
+  options: HttpRequestOptions | HttpsRequestOptions,
+  formData: FormData,
+  isHttpProxy=false,
+  ): Promise<string> {
   options.method = 'POST';
   options.headers = formData.getHeaders();
 
-  return sendRequest(options, formData);
+  return sendRequest(options, formData, isHttpProxy);
 }


### PR DESCRIPTION
Allow using a proxy, either via specialized HTTP headers or via an http/https agent like `tunnel` or `tunnel-agent`.